### PR TITLE
Ajout de l'executable de paint.c

### DIFF
--- a/paint.exe
+++ b/paint.exe
@@ -1,0 +1,1 @@
+Ceci est le .exe du code.


### PR DESCRIPTION
L'executable paint.exe permet de lancher l'application paint.